### PR TITLE
0.8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,7 @@ WORKDIR /burla
 RUN rm pyproject.toml && rm -rf ./src
 ADD ./src /burla/src
 ADD pyproject.toml /burla
+
+RUN /.pyenv/versions/3.10.*/bin/python3.10 -m pip install pandas numpy scikit-learn && \
+    /.pyenv/versions/3.11.*/bin/python3.11 -m pip install pandas numpy scikit-learn && \
+    /.pyenv/versions/3.12.*/bin/python3.12 -m pip install pandas numpy scikit-learn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "container_service"
-version = "0.8.4"
+version = "0.8.5"
 description = ""
 authors = ["Jacob Zuliani <jake@burla.dev>"]
 packages = [{include = "container_service", from = "src"}]

--- a/src/container_service/udf_executor.py
+++ b/src/container_service/udf_executor.py
@@ -48,7 +48,7 @@ class InputGetter:
         # grab doc
         input_pkl = None
         input_doc_url = f"{DB_BASE_URL}/inputs/{self.inputs_id}/{collection_name}/{input_index}"
-        for i in range(10):
+        for i in range(15):
             response = requests.get(input_doc_url, headers=self.db_headers)
             if response.status_code == 200:
                 input_pkl = base64.b64decode(response.json()["fields"]["input"]["bytesValue"])

--- a/src/container_service/udf_executor.py
+++ b/src/container_service/udf_executor.py
@@ -18,6 +18,88 @@ class EmptyInputQueue(Exception):
     pass
 
 
+<<<<<<< Updated upstream
+=======
+class InputGetter:
+    """
+    The policy implemented here is designed to minimize firestore document collisions.
+    If too many workers try to grab a firestore document (input) at the same time, stuff breaks.
+    """
+
+    def __init__(
+        self,
+        db_headers: dict,
+        inputs_id: str,
+        num_inputs: int,
+        starting_index: int,
+        parallelism: int,
+    ):
+        self.db_headers = db_headers
+        self.inputs_id = inputs_id
+        self.num_inputs = num_inputs
+        self.parallelism = parallelism
+        self.starting_index = starting_index
+        self.current_index = starting_index
+
+    def __attempt_to_claim_input(self, input_index: int) -> Union[None, bytes]:
+        batch_size = 100
+        batch_min_index = (input_index // batch_size) * batch_size
+        collection_name = f"{batch_min_index}-{batch_min_index + batch_size}"
+        SELF["WORKER_LOGS"].append(f"attempting to claim input {input_index}")
+
+        # grab doc
+        input_pkl = None
+        input_doc_url = f"{DB_BASE_URL}/inputs/{self.inputs_id}/{collection_name}/{input_index}"
+        for i in range(10):
+            response = requests.get(input_doc_url, headers=self.db_headers)
+            if response.status_code == 200:
+                input_pkl = base64.b64decode(response.json()["fields"]["input"]["bytesValue"])
+                is_claimed = response.json()["fields"]["claimed"]["booleanValue"]
+                break
+            if response.status_code != 404:
+                raise Exception(f"non 404/200 response trying to get input {input_index}?")
+            sleep(i * i * 0.1)  # 0.0, 0.1, 0.4, 0.9, 1.6, 2.5, 3.6, 4.9, 6.4, 8.1 ...
+
+        if not input_pkl:
+            raise Exception(f"DOCUMENT #{input_index} NOT FOUND after 10 attempts.")
+        elif is_claimed:
+            return None
+
+        # mark doc as claimed
+        SELF["WORKER_LOGS"].append(f"input found, marking input {input_index} as claimed")
+        update_claimed_url = f"{input_doc_url}?updateMask.fieldPaths=claimed"
+        data = {"fields": {"claimed": {"booleanValue": True}}}
+        response = requests.patch(update_claimed_url, headers=self.db_headers, json=data)
+        response.raise_for_status()
+        SELF["WORKER_LOGS"].append(f"successfully marked input {input_index} as claimed")
+        return input_pkl
+
+    def __get_next_index(self, old_index: int):
+        new_index = (old_index + self.parallelism) % self.num_inputs
+        if (new_index == self.starting_index) or (new_index == old_index):
+            new_index = (new_index + 1) % self.num_inputs
+            self.starting_index += 1
+        SELF["WORKER_LOGS"].append(f"computed new index: old={old_index}, new={new_index}")
+        return new_index
+
+    def get_next_input(self, attempt=0):
+
+        input_pkl = self.__attempt_to_claim_input(self.current_index)
+        input_index = self.current_index
+        self.current_index = self.__get_next_index(old_index=self.current_index)
+
+        if input_pkl:
+            return input_index, input_pkl
+        elif attempt == 5:
+            # If I try to claim 5 documents and they are all claimed then every document was
+            # checked 5 times and this worker can DEFINITELY stop trying! ?
+            # (or another worker is 5 docs ahead of this one and covering for it / will continue to)
+            raise EmptyInputQueue()
+        else:
+            return self.get_next_input(attempt=attempt + 1)
+
+
+>>>>>>> Stashed changes
 class _FirestoreLogger:
 
     def __init__(self, logs_collection_ref: CollectionReference, input_index: int):


### PR DESCRIPTION
**Supports Burla client release 0.8.5:**

- Increases max num of inputs RPM can take (~500 -> 5,000,000 - ish)
- Set limit on max size of all inputs combined to 84MB.

**Container Service specific changes:**

- Increases allowable time to wait for a udf-input firestore document to appear, in order to support more/larger inputs.
- adds a few python packages to default container.